### PR TITLE
Fix parsing for highlights without an author

### DIFF
--- a/src/KindleEntryParsed.ts
+++ b/src/KindleEntryParsed.ts
@@ -45,9 +45,8 @@ export class KindleEntryParsed {
     let ocurrenceIndex: number = bookTitleAndAuthors.indexOf("(");
 
     if (ocurrenceIndex === -1) {
-      throw new Error(
-        `Could not parse author from bookTitleAndAuthors of KindleEntry: ${bookTitleAndAuthors}`
-      );
+      this.authors = "";
+      return;
     }
 
     let nextOcurrenceIndex: number = bookTitleAndAuthors.indexOf(
@@ -79,6 +78,11 @@ export class KindleEntryParsed {
   parseBook() {
     const bookTitleAndAuthors: string = this.kindleEntry.bookTitleAndAuthors;
     let firstOccurrenceIndex: number = bookTitleAndAuthors.indexOf("(");
+    if (firstOccurrenceIndex === -1) {
+      this.bookTile = bookTitleAndAuthors.trim();
+      return;
+    }
+
     let nextOccurrenceIndex: number = bookTitleAndAuthors.indexOf(
       "(",
       firstOccurrenceIndex + 1

--- a/src/__tests__/KindleEntryParsed.test.ts
+++ b/src/__tests__/KindleEntryParsed.test.ts
@@ -63,12 +63,25 @@ const sampleEntries: Array<DataEntry> = [
     location: "3054-3056",
     dateOfCreation: "Ajouté le mercredi 16 août 2017 02:14:10",
     type: EntryType.Highlight
+  },
+  {
+    entry: new KindleEntry(
+      "Thinking in Systems",
+      "- Your Highlight on page 14 | Location 380-381 | Added on Saturday, April 13, 2019 3:43:59 PM",
+      "It’s easier to learn about a system’s elements than about its interconnections."
+    ),
+    titleParsed: "Thinking in Systems",
+    author: "",
+    page: 14,
+    location: "380-381",
+    dateOfCreation: "Added on Saturday, April 13, 2019 3:43:59 PM",
+    type: EntryType.Highlight
   }
 ];
 
 // eslint-disable-next-line no-undef
 describe("KindleEntryParsed", () => {
-
+ 
   describe("parseAuthor", () => {
     test("Obtains author", () => {
       // AAA


### PR DESCRIPTION
Highlights for books that do not have an author currently get parsed as an error:

```
Uncaught Error: Could not parse author from bookTitleAndAuthors of KindleEntry: ...
```

This PR allows for empty authors in highlights. (I suppose this could be seen as a breaking change, so it's up to your discretion if you want to merge this 🙂). 